### PR TITLE
nginx alias to serve static files

### DIFF
--- a/roles/graphite/templates/nginx-graphite.conf.j2
+++ b/roles/graphite/templates/nginx-graphite.conf.j2
@@ -8,6 +8,10 @@ server {
     # path for static files
     root /opt/graphite/webapp/content;
 
+    location /static {
+      alias /opt/graphite/webapp/content;
+    }
+
     location /media/ {
       # this changes depending on your python version
       root /opt/graphite/lib/python2.7/site-packages/django/contrib/admin;


### PR DESCRIPTION
I couldn't get the graphite static assets through nginx until I added this alias.
