### PR TITLE
Rename Redhat.yml to RedHat.yml

### DIFF
--- a/roles/graphite/vars/RedHat.yml
+++ b/roles/graphite/vars/RedHat.yml
@@ -1,0 +1,2 @@
+nginx_user: nginx
+nginx_group: nginx

--- a/roles/graphite/vars/Redhat.yml
+++ b/roles/graphite/vars/Redhat.yml
@@ -1,2 +1,0 @@
-nginx_user: nginx
-nginx_group: nginx


### PR DESCRIPTION
Ansible on CentOS 6.5 did not like the vars file called Redhat.yml. The Playbook installs fine when it is renamed to RedHat.yml