### PR TITLE
Use valid private ip

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,7 +6,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # graphite.vm.box = "centos/7"
     # graphite.vm.box = "debian/jessie64"
     monitoring.vm.box = "ubuntu/xenial64"
-    monitoring.vm.network :private_network, ip: "172.0.0.10"
+    monitoring.vm.network :private_network, ip: "192.168.50.4"
 
     monitoring.vm.provision "ansible_local" do |ansible| 
       ansible.playbook = "monitoring.yml"


### PR DESCRIPTION
As per the [Private IPv4 address space](https://en.wikipedia.org/wiki/Private_network#Private_IPv4_address_spaces), `172.0.0.10` is invalid and `192.168.50.4` is a valid vagrant [recommended default](https://www.vagrantup.com/docs/networking/private_network.html).
By using this new value, we can access the vagrant box's network via this valid private IP address.